### PR TITLE
copy returndata to memory in call(), revert if returndata size is ins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ To set up Foundry x Fe, first make sure you have [Fe](https://fe-lang.org/) inst
 
 Then follow the [Foundry installation guide](https://book.getfoundry.sh/getting-started/installation) to install Foundry.
 
+Install dependencies:
+
+```bash
+
+$ yarn install
+
+```
+
 Set up an environment variable `MAINNET_JSON_RPC` to point to a mainnet node. For example, you can use [Alchemy](https://alchemyapi.io/) or [Infura](https://infura.io/).
 
 # Run the examples

--- a/fe_contracts/defi/src/raw_call.fe
+++ b/fe_contracts/defi/src/raw_call.fe
@@ -21,40 +21,42 @@ pub struct RawCallHelper {
 
     /// Call a function directly by its selector on the given address. 
     pub fn call<T: MemoryEncoding>(_ addr: address, _ selector: u32, data: T) -> RawCallResult{
+        let mut start: u256
         unsafe {
             let input_offset: u256 = RawCallHelper::avail()
             [selector]
             data.write_mem()
-
+            start = RawCallHelper::avail() + data.byte_count()
             let success: u256 = std::evm::call(
                 gas: std::evm::gas_remaining(),
                 addr,
                 value: 0,
                 input_offset,
                 input_len: 4 + data.byte_count(),
-                output_offset: 0,
-                output_len: 0
+                output_offset: start,
+                output_len: 32
             )
             if success == 0 {
                 revert
             }
         }
 
-        return RawCallResult()
+        return RawCallResult(start)
     }
 }
 
 /// Result of raw call. Provides conversions to common types. Custom return types
 /// can be implemented by interpreting the raw memory directly
 pub struct RawCallResult {
-
+    pub start: u256
     /// Convert the raw call result to a u256
     pub fn to_u256(self) -> u256 {
         unsafe {
-            let output: u256 = RawCallHelper::avail()
             let output_size: u256 = std::evm::return_data_size()
-            std::evm::return_data_copy(to_offset: output, from_offset: 0, len: output_size)
-            return std::evm::mload(offset: output)
+            if output_size < 32 {
+                revert
+            }
+            return std::evm::mload(offset: self.start)
         }
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']

--- a/src/test/Swapper.t.sol
+++ b/src/test/Swapper.t.sol
@@ -52,4 +52,15 @@ contract SwapTest is Test {
       assert(new_weth_balance > initial_weth_balance);
       assertEq(new_weth_balance, initial_weth_balance + amount_out);
     }
+
+    function testLackOfContractCodeReverts() public {
+      uint256 amount_dai = 100_000;
+      ISwapper broken_swapper = ISwapper(Fe.deployContract("SwapExamples", abi.encode(address(0x0))));
+      try broken_swapper.swap_exact_input_single(amount_dai) {
+        // Call should revert if returndata is empty
+        assert(false);
+      } catch {
+
+      }
+    }
 }


### PR DESCRIPTION
…ufficient

Instead of calling returndatacopy, the call can copy return data to memory. Additionally, if there isn't a contract at the address that the swapper calls and it doesn't return data, it now reverts.